### PR TITLE
Python 3.12+ Compatability

### DIFF
--- a/nanolayer/installers/gh_release/resolvers/release_resolver.py
+++ b/nanolayer/installers/gh_release/resolvers/release_resolver.py
@@ -3,7 +3,7 @@ import logging
 import re
 import urllib
 from typing import Any, Dict, List, Optional
-import distutils.spawn
+import shutil
 
 import invoke
 from natsort import natsorted
@@ -84,7 +84,7 @@ class ReleaseResolver:
 
     @classmethod
     def _git_exists(cls) -> bool:
-        return distutils.spawn.find_executable("git") is not None
+        return shutil.which("git") is not None
 
     @classmethod
     def resolve(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydantic==1.10.7
+pydantic~=1.10.7
 typer==0.7.0
 click~=7.1
 invoke~=2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pydantic==1.10.7
 typer==0.7.0
-invoke==2.0.0
+invoke~=2.1
 natsort==8.3.1
 sentry-sdk==1.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pydantic==1.10.7
 typer==0.7.0
+click~=7.1
 invoke~=2.1
 natsort==8.3.1
 sentry-sdk==1.24.0


### PR DESCRIPTION
I have adjusted the pinned version of Invoke to a version that uses importlib instead of `imp`, pinned click to a version that doesn't raise an exception, and replaced the usage of distutils with shutil, in order to make the nanolayer library compatible with python 3.12+

Closes #10 