### PR TITLE
Fix: Normalize Git Tags received from GitHub Tag API, by dropping a 'v'-Prefix

### DIFF
--- a/nanolayer/installers/gh_release/resolvers/release_resolver.py
+++ b/nanolayer/installers/gh_release/resolvers/release_resolver.py
@@ -60,14 +60,15 @@ class ReleaseResolver:
         all_version_tags = cls.get_version_tags(repo, release_tag_regex)
 
         valid_versions = list(filter(cls.valid_version, all_version_tags))
-
         if len(valid_versions) != len(all_version_tags):
             logger.warning(
                 "The following release versions were filtered out as invalid: %s",
                 str(set(all_version_tags) - set(valid_versions)),
             )
 
-        return natsorted(valid_versions)[-1]
+        normalized_valid_versions = [version[1:] if version.startswith("v") else version for version in valid_versions]
+
+        return natsorted(normalized_valid_versions)[-1]
 
     @classmethod
     def get_latest_release_tag(


### PR DESCRIPTION
Fixes #16 

This is by far not the most general fix, but it helps with partial 'v'-prefixed tags like used by `ruff`.

@koralowiec  I hope that this repo will be maintained further, so that newer python compatibility can be ensured like #11 and fixes like this one, because it currently breaks the 'latest' option in some DevContainer Features.